### PR TITLE
Adding node-level logging optionality

### DIFF
--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -235,8 +235,8 @@ class RayDecorator(ParallelDecorator):
             # access to a ray cluster with expected number of nodes.
             self.setup_distributed_env(flow)
 
-            # Optionally tail Ray actor stdout/stderr to CloudWatch
-            # Only captures *.out and *.err files (actor output), not system logs
+            # Optionally tail Ray actor/task stdout/stderr to CloudWatch
+            # Only captures worker-*.out and worker-*.err files (actor output)
             log_tailer = None
             if self.attributes["enable_worker_logs"]:
                 log_tailer = RayLogTailer()

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -90,7 +90,7 @@ class RayDecorator(ParallelDecorator):
         "all_nodes_started_timeout": 90,
         "heartbeat_timeout": 60 * 10,  # 10 minutes
         "unreachable_timeout": 60 * 10,  # 10 minutes
-        "enable_worker_logs": False,  # Stream Ray logs to worker node CloudWatch
+        "enable_worker_logs": False,  # Stream Ray actor stdout/stderr to CloudWatch
         "ray_logging_level": None,  # Ray logging level (debug, info, warning, error)
         "ray_log_style": None,  # Ray log format (pretty, record, auto)
     }
@@ -234,13 +234,14 @@ class RayDecorator(ParallelDecorator):
             # all nodes have started. This ensures that user code will have
             # access to a ray cluster with expected number of nodes.
             self.setup_distributed_env(flow)
-            
-            # Optionally start tailing Ray logs to stream them to CloudWatch
+
+            # Optionally tail Ray actor stdout/stderr to CloudWatch
+            # Only captures *.out and *.err files (actor output), not system logs
             log_tailer = None
             if self.attributes["enable_worker_logs"]:
                 log_tailer = RayLogTailer()
                 log_tailer.start()
-            
+
             # The worker tasks will wait for the control task's heartbeat.
             # if it reaches a point where the control task failed for some reason
             # or the control task stopped publishing heartbeats, the worker task will fail.

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -2,6 +2,7 @@ import os
 import sys
 from functools import partial
 import json
+import tempfile
 from metaflow.unbounded_foreach import UBF_CONTROL
 from metaflow.plugins.parallel_decorator import (
     ParallelDecorator,
@@ -90,11 +91,12 @@ class RayDecorator(ParallelDecorator):
         "all_nodes_started_timeout": 90,
         "heartbeat_timeout": 60 * 10,  # 10 minutes
         "unreachable_timeout": 60 * 10,  # 10 minutes
-        "enable_worker_logs": False,  # Stream Ray actor stdout/stderr to CloudWatch
-        "ray_logging_level": None,  # Ray logging level (debug, info, warning, error)
-        "ray_log_style": None,  # Ray log format (pretty, record, auto)
+        "enable_worker_logs": False,  # Stream Ray actor stdout/stderr to stdout
+        "logging_level": None,  # Ray logging level (debug, info, warning, error)
+        "log_style": None,  # Ray log format (pretty, record, auto)
     }
     IS_PARALLEL = True
+    VALID_LOG_STYLES = ["pretty", "record", "auto"]
 
     def step_init(
         self, flow, graph, step_name, decorators, environment, flow_datastore, logger
@@ -104,6 +106,16 @@ class RayDecorator(ParallelDecorator):
         )
         self.flow_datastore = flow_datastore
         self._heartbeat_thread = None
+        self.ray_temp_dir = None
+
+        # Validate log_style parameter
+        log_style = self.attributes.get("log_style")
+        if log_style is not None:
+            if log_style not in self.VALID_LOG_STYLES:
+                raise ValueError(
+                    f"Invalid log_style: '{log_style}'. "
+                    f"Valid options are: {', '.join(self.VALID_LOG_STYLES)}"
+                )
 
     def task_pre_step(
         self,
@@ -235,11 +247,15 @@ class RayDecorator(ParallelDecorator):
             # access to a ray cluster with expected number of nodes.
             self.setup_distributed_env(flow)
 
-            # Optionally tail Ray actor/task stdout/stderr to CloudWatch
+            # Optionally tail Ray actor/task stdout/stderr
             # Only captures worker-*.out and worker-*.err files (actor output)
             log_tailer = None
             if self.attributes["enable_worker_logs"]:
-                log_tailer = RayLogTailer()
+                log_tailer = RayLogTailer(
+                    ray_temp_dir=self.ray_temp_dir,
+                    poll_interval=1.0,
+                    include_patterns=["worker-*.out", "worker-*.err"],
+                )
                 log_tailer.start()
 
             # The worker tasks will wait for the control task's heartbeat.
@@ -293,6 +309,10 @@ class RayDecorator(ParallelDecorator):
         - Wait for all ray nodes to join the cluster (on both worker and control.)
         """
         self.wait_for_all_nodes_to_start()
+
+        # Create a temporary directory for Ray
+        self.ray_temp_dir = tempfile.mkdtemp(prefix="metaflow_ray_")
+
         main_port = self._resolve_port()
         main_ip = resolve_main_ip()
         start_ray_processes(
@@ -300,7 +320,8 @@ class RayDecorator(ParallelDecorator):
             main_ip,
             main_port,
             current.parallel.node_index,
-            logging_level=self.attributes["ray_logging_level"],
-            log_style=self.attributes["ray_log_style"],
+            temp_dir=self.ray_temp_dir,
+            logging_level=self.attributes["logging_level"],
+            log_style=self.attributes["log_style"],
         )
         wait_for_ray_nodes_to_join(self.attributes["all_nodes_started_timeout"] or 300)

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -48,7 +48,6 @@ def _worker_node_heartbeat_monitor(
     - Control task fails intermittently.
     - The worker/control fails intermittently such as node being wiped off
     """
-    # TODO : Make heartbeat timeout configurable
     _status_notifier = TaskStatusNotifier(datastore)
     # Worker task statuses are only for bookkeeping.
     # They are not used by the control task in any way.
@@ -88,6 +87,8 @@ class RayDecorator(ParallelDecorator):
         "main_port": None,
         "worker_polling_freq": 10,  # We DONT use this anymore
         "all_nodes_started_timeout": 90,
+        "heartbeat_timeout": 60 * 10,  # 10 minutes
+        "unreachable_timeout": 60 * 10,  # 10 minutes
     }
     IS_PARALLEL = True
 
@@ -235,7 +236,8 @@ class RayDecorator(ParallelDecorator):
             _worker_node_heartbeat_monitor(
                 self.deco_datastore,
                 current.parallel.node_index,
-                heartbeat_timeout=10 * 60,  # 10 minutes (todo: make this configurable)
+                heartbeat_timeout=self.attributes["heartbeat_timeout"],
+                unreachable_timeout=self.attributes["unreachable_timeout"],
             )
 
         # A status notifier helps the control node publish heartbeats

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -25,6 +25,7 @@ from .ray_utils import (
     warning_message,
     wait_for_ray_nodes_to_join,
 )
+from .ray_log_tailer import RayLogTailer
 from .constants import RAY_SUFFIX
 
 
@@ -89,6 +90,9 @@ class RayDecorator(ParallelDecorator):
         "all_nodes_started_timeout": 90,
         "heartbeat_timeout": 60 * 10,  # 10 minutes
         "unreachable_timeout": 60 * 10,  # 10 minutes
+        "enable_worker_logs": False,  # Stream Ray logs to worker node CloudWatch
+        "ray_logging_level": None,  # Ray logging level (debug, info, warning, error)
+        "ray_log_style": None,  # Ray log format (pretty, record, auto)
     }
     IS_PARALLEL = True
 
@@ -230,15 +234,26 @@ class RayDecorator(ParallelDecorator):
             # all nodes have started. This ensures that user code will have
             # access to a ray cluster with expected number of nodes.
             self.setup_distributed_env(flow)
+            
+            # Optionally start tailing Ray logs to stream them to CloudWatch
+            log_tailer = None
+            if self.attributes["enable_worker_logs"]:
+                log_tailer = RayLogTailer()
+                log_tailer.start()
+            
             # The worker tasks will wait for the control task's heartbeat.
             # if it reaches a point where the control task failed for some reason
             # or the control task stopped publishing heartbeats, the worker task will fail.
-            _worker_node_heartbeat_monitor(
-                self.deco_datastore,
-                current.parallel.node_index,
-                heartbeat_timeout=self.attributes["heartbeat_timeout"],
-                unreachable_timeout=self.attributes["unreachable_timeout"],
-            )
+            try:
+                _worker_node_heartbeat_monitor(
+                    self.deco_datastore,
+                    current.parallel.node_index,
+                    heartbeat_timeout=self.attributes["heartbeat_timeout"],
+                    unreachable_timeout=self.attributes["unreachable_timeout"],
+                )
+            finally:
+                if log_tailer:
+                    log_tailer.stop()
 
         # A status notifier helps the control node publish heartbeats
         # and it helps the worker nodes monitor the control node's heartbeat.
@@ -280,6 +295,11 @@ class RayDecorator(ParallelDecorator):
         main_port = self._resolve_port()
         main_ip = resolve_main_ip()
         start_ray_processes(
-            self.ubf_context, main_ip, main_port, current.parallel.node_index
+            self.ubf_context,
+            main_ip,
+            main_port,
+            current.parallel.node_index,
+            logging_level=self.attributes["ray_logging_level"],
+            log_style=self.attributes["ray_log_style"],
         )
         wait_for_ray_nodes_to_join(self.attributes["all_nodes_started_timeout"] or 300)

--- a/metaflow_extensions/ray/plugins/ray_log_tailer.py
+++ b/metaflow_extensions/ray/plugins/ray_log_tailer.py
@@ -16,8 +16,9 @@ class RayLogTailer:
         self.running = False
         self.thread = None
         self.file_positions = {}
-        # Default: only capture actor stdout/stderr, not system logs
-        self.include_patterns = include_patterns or ["*.out", "*.err"]
+        # Default: only capture worker stdout/stderr (actor output)
+        # worker-*.out/err excludes system components like raylet.out, gcs_server.out
+        self.include_patterns = include_patterns or ["worker-*.out", "worker-*.err"]
 
     def _find_ray_session_dir(self):
         """Find the Ray session directory."""
@@ -64,9 +65,7 @@ class RayLogTailer:
             if session_dir:
                 logs_dir = os.path.join(session_dir, "logs")
                 if os.path.exists(logs_dir):
-                    # Tail log files based on include_patterns
-                    # *.out/*.err = Actor/task stdout/stderr (print statements!)
-                    # *.log = Ray system logs (raylet, gcs, etc.) - often noisy
+                    # Tail worker output files only (worker-*.out, worker-*.err)
                     for pattern in self.include_patterns:
                         full_pattern = os.path.join(logs_dir, pattern)
                         for log_file in glob.glob(full_pattern):

--- a/metaflow_extensions/ray/plugins/ray_log_tailer.py
+++ b/metaflow_extensions/ray/plugins/ray_log_tailer.py
@@ -10,12 +10,14 @@ class RayLogTailer:
     Tails Ray log files and streams them to stdout so they appear in CloudWatch logs.
     """
 
-    def __init__(self, ray_session_dir=None, poll_interval=1.0):
+    def __init__(self, ray_session_dir=None, poll_interval=1.0, include_patterns=None):
         self.ray_session_dir = ray_session_dir
         self.poll_interval = poll_interval
         self.running = False
         self.thread = None
         self.file_positions = {}
+        # Default: only capture actor stdout/stderr, not system logs
+        self.include_patterns = include_patterns or ["*.out", "*.err"]
 
     def _find_ray_session_dir(self):
         """Find the Ray session directory."""
@@ -62,10 +64,13 @@ class RayLogTailer:
             if session_dir:
                 logs_dir = os.path.join(session_dir, "logs")
                 if os.path.exists(logs_dir):
-                    # Tail all log files in the logs directory
-                    log_files = glob.glob(os.path.join(logs_dir, "*.log"))
-                    for log_file in log_files:
-                        self._tail_file(log_file)
+                    # Tail log files based on include_patterns
+                    # *.out/*.err = Actor/task stdout/stderr (print statements!)
+                    # *.log = Ray system logs (raylet, gcs, etc.) - often noisy
+                    for pattern in self.include_patterns:
+                        full_pattern = os.path.join(logs_dir, pattern)
+                        for log_file in glob.glob(full_pattern):
+                            self._tail_file(log_file)
 
             time.sleep(self.poll_interval)
 

--- a/metaflow_extensions/ray/plugins/ray_log_tailer.py
+++ b/metaflow_extensions/ray/plugins/ray_log_tailer.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import glob
 import threading
@@ -7,29 +8,28 @@ from pathlib import Path
 
 class RayLogTailer:
     """
-    Tails Ray log files and streams them to stdout so they appear in CloudWatch logs.
+    Tails Ray log files and streams them to stdout.
     """
 
-    def __init__(self, ray_session_dir=None, poll_interval=1.0, include_patterns=None):
-        self.ray_session_dir = ray_session_dir
+    def __init__(self, ray_temp_dir, poll_interval, include_patterns):
+        self.ray_temp_dir = ray_temp_dir
         self.poll_interval = poll_interval
-        self.running = False
+        self.stop_event = threading.Event()
         self.thread = None
         self.file_positions = {}
-        # Default: only capture worker stdout/stderr (actor output)
+        # Only capture worker stdout/stderr (actor output)
         # worker-*.out/err excludes system components like raylet.out, gcs_server.out
-        self.include_patterns = include_patterns or ["worker-*.out", "worker-*.err"]
+        self.include_patterns = include_patterns
 
     def _find_ray_session_dir(self):
-        """Find the Ray session directory."""
-        if self.ray_session_dir:
-            return self.ray_session_dir
+        """Find the Ray session directory using the session_latest symlink."""
+        if not self.ray_temp_dir:
+            return None
 
-        # Ray typically creates session dirs in /tmp/ray/session_*
-        ray_tmp_dirs = glob.glob("/tmp/ray/session_*")
-        if ray_tmp_dirs:
-            # Get the most recent session directory
-            return max(ray_tmp_dirs, key=os.path.getmtime)
+        # Ray creates a session_latest symlink to the current session directory
+        session_latest = os.path.join(self.ray_temp_dir, "session_latest")
+        if os.path.exists(session_latest):
+            return session_latest
         return None
 
     def _tail_file(self, filepath):
@@ -59,38 +59,50 @@ class RayLogTailer:
         """Main loop that tails all Ray log files."""
         print("[RAY_LOG_TAILER] Starting Ray log tailer...")
 
-        while self.running:
-            session_dir = self._find_ray_session_dir()
+        # Find the session directory once before starting the loop
+        session_dir = self._find_ray_session_dir()
+        if not session_dir:
+            print(
+                "[RAY_LOG_TAILER] Ray session directory not found. Cannot tail logs.",
+                file=sys.stderr,
+            )
+            return
 
-            if session_dir:
-                logs_dir = os.path.join(session_dir, "logs")
-                if os.path.exists(logs_dir):
-                    # Tail worker output files only (worker-*.out, worker-*.err)
-                    for pattern in self.include_patterns:
-                        full_pattern = os.path.join(logs_dir, pattern)
-                        for log_file in glob.glob(full_pattern):
-                            self._tail_file(log_file)
+        logs_dir = os.path.join(session_dir, "logs")
+        if not os.path.exists(logs_dir):
+            print(
+                f"[RAY_LOG_TAILER] Ray logs directory not found at {logs_dir}. Cannot tail logs.",
+                file=sys.stderr,
+            )
+            return
 
-            time.sleep(self.poll_interval)
+        # Tail worker output files in the loop
+        while not self.stop_event.is_set():
+            for pattern in self.include_patterns:
+                full_pattern = os.path.join(logs_dir, pattern)
+                for log_file in glob.glob(full_pattern):
+                    self._tail_file(log_file)
+
+            # Wait for poll_interval or until stop_event is set
+            self.stop_event.wait(self.poll_interval)
 
         print("[RAY_LOG_TAILER] Stopped Ray log tailer")
 
     def start(self):
         """Start tailing Ray logs in a background thread."""
-        if self.running:
+        if self.thread and self.thread.is_alive():
             return
 
-        self.running = True
+        self.stop_event.clear()
         self.thread = threading.Thread(target=self._tail_loop, daemon=True)
         self.thread.start()
         print("[RAY_LOG_TAILER] Ray log tailer thread started")
 
     def stop(self):
         """Stop tailing Ray logs."""
-        if not self.running:
+        if not self.thread or not self.thread.is_alive():
             return
 
-        self.running = False
-        if self.thread:
-            self.thread.join(timeout=5)
+        self.stop_event.set()
+        self.thread.join(timeout=5)
         print("[RAY_LOG_TAILER] Ray log tailer stopped")

--- a/metaflow_extensions/ray/plugins/ray_log_tailer.py
+++ b/metaflow_extensions/ray/plugins/ray_log_tailer.py
@@ -1,0 +1,92 @@
+import os
+import time
+import glob
+import threading
+from pathlib import Path
+
+
+class RayLogTailer:
+    """
+    Tails Ray log files and streams them to stdout so they appear in CloudWatch logs.
+    """
+
+    def __init__(self, ray_session_dir=None, poll_interval=1.0):
+        self.ray_session_dir = ray_session_dir
+        self.poll_interval = poll_interval
+        self.running = False
+        self.thread = None
+        self.file_positions = {}
+
+    def _find_ray_session_dir(self):
+        """Find the Ray session directory."""
+        if self.ray_session_dir:
+            return self.ray_session_dir
+
+        # Ray typically creates session dirs in /tmp/ray/session_*
+        ray_tmp_dirs = glob.glob("/tmp/ray/session_*")
+        if ray_tmp_dirs:
+            # Get the most recent session directory
+            return max(ray_tmp_dirs, key=os.path.getmtime)
+        return None
+
+    def _tail_file(self, filepath):
+        """Tail a single log file and print new lines."""
+        try:
+            # Get current position or start from beginning
+            if filepath not in self.file_positions:
+                self.file_positions[filepath] = 0
+
+            with open(filepath, "r") as f:
+                f.seek(self.file_positions[filepath])
+                new_lines = f.readlines()
+
+                if new_lines:
+                    # Print with prefix to identify source
+                    filename = os.path.basename(filepath)
+                    for line in new_lines:
+                        print(f"[RAY:{filename}] {line.rstrip()}")
+
+                # Update position
+                self.file_positions[filepath] = f.tell()
+        except Exception as e:
+            # File might not exist yet or might be rotated
+            pass
+
+    def _tail_loop(self):
+        """Main loop that tails all Ray log files."""
+        print("[RAY_LOG_TAILER] Starting Ray log tailer...")
+
+        while self.running:
+            session_dir = self._find_ray_session_dir()
+
+            if session_dir:
+                logs_dir = os.path.join(session_dir, "logs")
+                if os.path.exists(logs_dir):
+                    # Tail all log files in the logs directory
+                    log_files = glob.glob(os.path.join(logs_dir, "*.log"))
+                    for log_file in log_files:
+                        self._tail_file(log_file)
+
+            time.sleep(self.poll_interval)
+
+        print("[RAY_LOG_TAILER] Stopped Ray log tailer")
+
+    def start(self):
+        """Start tailing Ray logs in a background thread."""
+        if self.running:
+            return
+
+        self.running = True
+        self.thread = threading.Thread(target=self._tail_loop, daemon=True)
+        self.thread.start()
+        print("[RAY_LOG_TAILER] Ray log tailer thread started")
+
+    def stop(self):
+        """Stop tailing Ray logs."""
+        if not self.running:
+            return
+
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=5)
+        print("[RAY_LOG_TAILER] Ray log tailer stopped")

--- a/metaflow_extensions/ray/plugins/ray_utils.py
+++ b/metaflow_extensions/ray/plugins/ray_utils.py
@@ -39,7 +39,7 @@ def warning_message(message, prefix="[@metaflow_ray]"):
 
 
 def start_ray_processes(
-    ubf_context, main_ip, main_port, node_index, logging_level=None, log_style=None
+    ubf_context, main_ip, main_port, node_index, temp_dir, logging_level=None, log_style=None
 ):
     # When ray processes start and finish properly it means that the process
     # would have successfully registered as a part of the cluster.
@@ -57,6 +57,8 @@ def start_ray_processes(
                 main_ip,
                 "--port",
                 str(main_port),
+                "--temp-dir",
+                temp_dir,
                 "--disable-usage-stats",
             ]
             if logging_level:
@@ -82,6 +84,8 @@ def start_ray_processes(
                 node_ip_address,
                 "--address",
                 "%s:%s" % (main_ip, main_port),
+                "--temp-dir",
+                temp_dir,
                 "--disable-usage-stats",
             ]
             if logging_level:

--- a/metaflow_extensions/ray/plugins/ray_utils.py
+++ b/metaflow_extensions/ray/plugins/ray_utils.py
@@ -38,26 +38,34 @@ def warning_message(message, prefix="[@metaflow_ray]"):
     print(msg, file=sys.stderr)
 
 
-def start_ray_processes(ubf_context, main_ip, main_port, node_index):
+def start_ray_processes(
+    ubf_context, main_ip, main_port, node_index, logging_level=None, log_style=None
+):
     # When ray processes start and finish properly it means that the process
     # would have successfully registered as a part of the cluster.
     import ray
 
     try:
         if ubf_context == UBF_CONTROL:
+            cmd = [
+                sys.executable,
+                "-m",
+                "ray.scripts.scripts",
+                "start",
+                "--head",
+                "--node-ip-address",
+                main_ip,
+                "--port",
+                str(main_port),
+                "--disable-usage-stats",
+            ]
+            if logging_level:
+                cmd.extend(["--logging-level", logging_level])
+            if log_style:
+                cmd.extend(["--log-style", log_style])
+
             runtime_start_result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "ray.scripts.scripts",
-                    "start",
-                    "--head",
-                    "--node-ip-address",
-                    main_ip,
-                    "--port",
-                    str(main_port),
-                    "--disable-usage-stats",
-                ],
+                cmd,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -65,18 +73,24 @@ def start_ray_processes(ubf_context, main_ip, main_port, node_index):
 
         else:
             node_ip_address = ray._private.services.get_node_ip_address()
+            cmd = [
+                sys.executable,
+                "-m",
+                "ray.scripts.scripts",
+                "start",
+                "--node-ip-address",
+                node_ip_address,
+                "--address",
+                "%s:%s" % (main_ip, main_port),
+                "--disable-usage-stats",
+            ]
+            if logging_level:
+                cmd.extend(["--logging-level", logging_level])
+            if log_style:
+                cmd.extend(["--log-style", log_style])
+
             runtime_start_result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "ray.scripts.scripts",
-                    "start",
-                    "--node-ip-address",
-                    node_ip_address,
-                    "--address",
-                    "%s:%s" % (main_ip, main_port),
-                    "--disable-usage-stats",
-                ],
+                cmd,
                 check=True,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Right now, Ray writes to std err/out files that are not captured by in std err/out pipes. This PR creates a daemon that periodically reads and spits out these logs so that they can be monitored for a given worker/node.