### PR TITLE
Support running the dashboard process explicitly + fix tempfile bug 

### DIFF
--- a/metaflow_extensions/ray/plugins/constants.py
+++ b/metaflow_extensions/ray/plugins/constants.py
@@ -1,2 +1,6 @@
 NODE_STARTED_VAR = "ray_node_started"
 RAY_SUFFIX = "mf.ray_decorator"
+DEFAULT_DASHBOARD_PORT = 8265
+# Ray binds the dashboard to localhost by default, which makes it unreachable
+# from outside the control task's container. We always bind to all interfaces.
+DASHBOARD_HOST = "0.0.0.0"

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -2,7 +2,6 @@ import os
 import sys
 from functools import partial
 import json
-import tempfile
 from metaflow.unbounded_foreach import UBF_CONTROL
 from metaflow.plugins.parallel_decorator import (
     ParallelDecorator,
@@ -25,9 +24,10 @@ from .ray_utils import (
     start_ray_processes,
     warning_message,
     wait_for_ray_nodes_to_join,
+    default_ray_temp_dir,
 )
 from .ray_log_tailer import RayLogTailer
-from .constants import RAY_SUFFIX
+from .constants import RAY_SUFFIX, DEFAULT_DASHBOARD_PORT
 
 
 def _worker_node_heartbeat_monitor(
@@ -94,6 +94,8 @@ class RayDecorator(ParallelDecorator):
         "enable_worker_logs": False,  # Stream Ray actor stdout/stderr to stdout
         "logging_level": None,  # Ray logging level (debug, info, warning, error)
         "log_style": None,  # Ray log format (pretty, record, auto)
+        "enable_dashboard": False,  # Start the Ray dashboard on the control node
+        "dashboard_port": DEFAULT_DASHBOARD_PORT,  # Port the dashboard listens on
     }
     IS_PARALLEL = True
     VALID_LOG_STYLES = ["pretty", "record", "auto"]
@@ -116,6 +118,23 @@ class RayDecorator(ParallelDecorator):
                     f"Invalid log_style: '{log_style}'. "
                     f"Valid options are: {', '.join(self.VALID_LOG_STYLES)}"
                 )
+
+        # Validate dashboard_port parameter
+        dashboard_port = self.attributes.get("dashboard_port")
+        if dashboard_port is None:
+            self.attributes["dashboard_port"] = DEFAULT_DASHBOARD_PORT
+        else:
+            # Attributes can reach us as strings when the step is scheduled remotely.
+            try:
+                port = int(str(dashboard_port))
+            except ValueError:
+                port = None
+            if port is None or not 1 <= port <= 65535:
+                raise ValueError(
+                    f"Invalid dashboard_port: '{dashboard_port}'. "
+                    "It must be an integer between 1 and 65535."
+                )
+            self.attributes["dashboard_port"] = port
 
     def task_pre_step(
         self,
@@ -310,8 +329,11 @@ class RayDecorator(ParallelDecorator):
         """
         self.wait_for_all_nodes_to_start()
 
-        # Create a temporary directory for Ray
-        self.ray_temp_dir = tempfile.mkdtemp(prefix="metaflow_ray_")
+        # Let ray use its default temp directory. Ray records the cluster's address in
+        # `<temp_dir>/ray_current_cluster` and that is the only place an address-less
+        # `ray.init()` looks, so pointing ray at a directory of our own would make user
+        # code silently start its own single node cluster instead of joining this one.
+        self.ray_temp_dir = default_ray_temp_dir()
 
         main_port = self._resolve_port()
         main_ip = resolve_main_ip()
@@ -320,8 +342,11 @@ class RayDecorator(ParallelDecorator):
             main_ip,
             main_port,
             current.parallel.node_index,
-            temp_dir=self.ray_temp_dir,
             logging_level=self.attributes["logging_level"],
             log_style=self.attributes["log_style"],
+            enable_dashboard=self.attributes["enable_dashboard"],
+            dashboard_port=self.attributes["dashboard_port"],
         )
-        wait_for_ray_nodes_to_join(self.attributes["all_nodes_started_timeout"] or 300)
+        wait_for_ray_nodes_to_join(
+            self.attributes["all_nodes_started_timeout"] or 300, main_ip, main_port
+        )

--- a/metaflow_extensions/ray/plugins/ray_decorator.py
+++ b/metaflow_extensions/ray/plugins/ray_decorator.py
@@ -130,8 +130,8 @@ class RayDecorator(ParallelDecorator):
             except ValueError:
                 port = None
             if port is None or not 1 <= port <= 65535:
-                raise ValueError(
-                    f"Invalid dashboard_port: '{dashboard_port}'. "
+                raise RayException(
+                    f"Invalid dashboard_port provided to @metaflow_ray : '{dashboard_port}'. "
                     "It must be an integer between 1 and 65535."
                 )
             self.attributes["dashboard_port"] = port

--- a/metaflow_extensions/ray/plugins/ray_started_check.py
+++ b/metaflow_extensions/ray/plugins/ray_started_check.py
@@ -5,12 +5,14 @@ import json
 import sys
 
 
-def check_ray_started(main_node_ip):
+def check_ray_started(head_address):
     import ray
 
-    ray.init(
-        _node_ip_address=main_node_ip,
-    )
+    # Connect to the cluster explicitly instead of letting `ray.init()` discover it.
+    # The decorator starts ray with a custom `--temp-dir`, so the address file that
+    # `ray.init()` reads by default (/tmp/ray/ray_current_cluster) is never written,
+    # and an address-less `ray.init()` would silently start its own 1-node cluster.
+    ray.init(address=head_address)
     ray_nodes = ray.nodes()
     print(json.dumps(ray_nodes))
 

--- a/metaflow_extensions/ray/plugins/ray_utils.py
+++ b/metaflow_extensions/ray/plugins/ray_utils.py
@@ -39,8 +39,7 @@ def warning_message(message, prefix="[@metaflow_ray]"):
     print(msg, file=sys.stderr)
 
 
-# Ray renamed this helper between versions, so try both before falling back to the
-# layout ray documents (`<system temp dir>/ray`).
+# Ray renamed this helper between versions, so try both.
 _TEMP_DIR_GETTERS = [
     ("ray._common.utils", "get_default_ray_temp_dir"),  # ray >= 2.40
     ("ray._private.utils", "get_ray_temp_dir"),  # older ray
@@ -49,7 +48,10 @@ _TEMP_DIR_GETTERS = [
 
 def default_ray_temp_dir():
     # The root temp dir that `ray start` uses when `--temp-dir` is not passed. Ray keeps
-    # the cluster address file and the session logs under here.
+    # the cluster address file and the session logs under here. We ask ray for this path
+    # rather than guessing it: ray resolves it differently per platform and honours
+    # RAY_TMPDIR/TMPDIR, so a hardcoded fallback could silently point us at a directory
+    # ray is not using.
     import importlib
 
     for module_name, fn_name in _TEMP_DIR_GETTERS:
@@ -57,9 +59,11 @@ def default_ray_temp_dir():
             return getattr(importlib.import_module(module_name), fn_name)()
         except (ImportError, AttributeError):
             continue
-    import tempfile
-
-    return os.path.join(tempfile.gettempdir(), "ray")
+    raise RayException(
+        "Could not determine the temporary directory used by `ray`. Tried %s. "
+        "This most likely means @metaflow_ray does not support the installed ray "
+        "version yet." % ", ".join("%s.%s" % (m, f) for m, f in _TEMP_DIR_GETTERS)
+    )
 
 
 def start_ray_processes(

--- a/metaflow_extensions/ray/plugins/ray_utils.py
+++ b/metaflow_extensions/ray/plugins/ray_utils.py
@@ -10,6 +10,7 @@ from .exceptions import (
 )
 from metaflow.metaflow_current import current
 from metaflow.unbounded_foreach import UBF_CONTROL
+from .constants import DASHBOARD_HOST, DEFAULT_DASHBOARD_PORT
 
 RAY_NODE_EXTRACTOR_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "ray_started_check.py"
@@ -38,8 +39,38 @@ def warning_message(message, prefix="[@metaflow_ray]"):
     print(msg, file=sys.stderr)
 
 
+# Ray renamed this helper between versions, so try both before falling back to the
+# layout ray documents (`<system temp dir>/ray`).
+_TEMP_DIR_GETTERS = [
+    ("ray._common.utils", "get_default_ray_temp_dir"),  # ray >= 2.40
+    ("ray._private.utils", "get_ray_temp_dir"),  # older ray
+]
+
+
+def default_ray_temp_dir():
+    # The root temp dir that `ray start` uses when `--temp-dir` is not passed. Ray keeps
+    # the cluster address file and the session logs under here.
+    import importlib
+
+    for module_name, fn_name in _TEMP_DIR_GETTERS:
+        try:
+            return getattr(importlib.import_module(module_name), fn_name)()
+        except (ImportError, AttributeError):
+            continue
+    import tempfile
+
+    return os.path.join(tempfile.gettempdir(), "ray")
+
+
 def start_ray_processes(
-    ubf_context, main_ip, main_port, node_index, temp_dir, logging_level=None, log_style=None
+    ubf_context,
+    main_ip,
+    main_port,
+    node_index,
+    logging_level=None,
+    log_style=None,
+    enable_dashboard=False,
+    dashboard_port=DEFAULT_DASHBOARD_PORT,
 ):
     # When ray processes start and finish properly it means that the process
     # would have successfully registered as a part of the cluster.
@@ -57,10 +88,21 @@ def start_ray_processes(
                 main_ip,
                 "--port",
                 str(main_port),
-                "--temp-dir",
-                temp_dir,
                 "--disable-usage-stats",
             ]
+            if enable_dashboard:
+                # The dashboard only ever runs on the head node, and `ray start`
+                # rejects these flags when `--head` is absent.
+                cmd.extend(
+                    [
+                        "--include-dashboard",
+                        "true",
+                        "--dashboard-host",
+                        DASHBOARD_HOST,
+                        "--dashboard-port",
+                        str(dashboard_port),
+                    ]
+                )
             if logging_level:
                 cmd.extend(["--logging-level", logging_level])
             if log_style:
@@ -84,8 +126,6 @@ def start_ray_processes(
                 node_ip_address,
                 "--address",
                 "%s:%s" % (main_ip, main_port),
-                "--temp-dir",
-                temp_dir,
                 "--disable-usage-stats",
             ]
             if logging_level:
@@ -103,10 +143,19 @@ def start_ray_processes(
         process_type = "control" if ubf_context == UBF_CONTROL else "worker"
         e.stderr = e.stderr.replace("\n", "\n\t")
         e.stdout = e.stdout.replace("\n", "\n\t")
-        raise RayException(
+        message = (
             "Ray processes [%s][on node-index %s] failed to start with exception:\n%s\n%s"
             % (process_type, str(node_index), e.stderr, e.stdout)
         )
+        if ubf_context == UBF_CONTROL and enable_dashboard:
+            # `--include-dashboard true` makes ray start fail hard if the dashboard's
+            # dependencies are missing, instead of warning and moving on.
+            message += (
+                "\n\t`@metaflow_ray(enable_dashboard=True)` requires the dashboard's dependencies "
+                "to be installed in the execution environment (`pip install 'ray[default]'`). "
+                "Either install them or set `enable_dashboard=False`."
+            )
+        raise RayException(message)
     warning_message(
         "Ray processes started successfully on node-index %s [%s]"
         % (
@@ -114,25 +163,38 @@ def start_ray_processes(
             "control" if ubf_context == UBF_CONTROL else "worker",
         )
     )
+    if ubf_context == UBF_CONTROL and enable_dashboard:
+        warning_message(
+            "Ray dashboard is running on port %s of the control task [http://%s:%s]. "
+            % (
+                str(dashboard_port),
+                main_ip,
+                str(dashboard_port),
+            )
+        )
     return runtime_start_result
 
 
-def _extract_ray_nodes():
+def _extract_ray_nodes(head_address):
+    # Returns a (nodes, error) tuple. `nodes` is None when the node list could not be
+    # read, in which case `error` explains why; swallowing that error makes cluster
+    # formation problems impossible to diagnose from the task logs.
     try:
         completed_proc = subprocess.run(
-            [sys.executable, RAY_NODE_EXTRACTOR_FILE, resolve_main_ip()],
+            [sys.executable, RAY_NODE_EXTRACTOR_FILE, head_address],
             check=True,
             capture_output=True,
         )
-        data_str = completed_proc.stdout.decode()
-        return json.loads(data_str)
     except subprocess.CalledProcessError as e:
-        return None
+        return None, e.stderr.decode(errors="replace").strip()
+    data_str = completed_proc.stdout.decode()
+    try:
+        return json.loads(data_str), None
     except json.JSONDecodeError:
-        return None
+        return None, "Could not parse the `ray` node list: %s" % data_str.strip()
 
 
-def wait_for_ray_nodes_to_join(max_wait_time):
+def wait_for_ray_nodes_to_join(max_wait_time, main_ip, main_port):
     # This function will wait untill all ray nodes have joined the cluster.
     # If nodes have not joined after a certain amount of timeout it will raise an exception.
     # We leverage subprocesses to extract the number of nodes that have joined the cluster.
@@ -140,10 +202,11 @@ def wait_for_ray_nodes_to_join(max_wait_time):
     # Extracting number of nodes in a separate subprocess ensures that when users call `ray.init`,
     # ray will not end up throwing and exception.
 
+    head_address = "%s:%s" % (main_ip, main_port)
     start_time = time.time()
     _iters = 0
     while True:
-        ray_nodes = _extract_ray_nodes()
+        ray_nodes, probe_error = _extract_ray_nodes(head_address)
         if ray_nodes is not None:
             if len(ray_nodes) == current.parallel.num_nodes:
                 warning_message(
@@ -155,12 +218,23 @@ def wait_for_ray_nodes_to_join(max_wait_time):
         if _iters % 10 == 0:
             warning_message(
                 "Waiting for all `ray` nodes to join the cluster. Current number of nodes in cluster: %s"
-                % str(len(ray_nodes))
+                % (str(len(ray_nodes)) if ray_nodes is not None else "unknown")
             )
+            if probe_error:
+                warning_message(
+                    "Could not read the `ray` node list from %s: %s"
+                    % (head_address, probe_error)
+                )
         _iters += 1
         time.sleep(1)
         if time.time() - start_time > max_wait_time:
-            raise RayException(
+            message = (
                 "All `ray` nodes did not join the cluster in %s seconds."
                 % max_wait_time
             )
+            if probe_error:
+                message += (
+                    " The last attempt to read the node list from %s failed with: %s"
+                    % (head_address, probe_error)
+                )
+            raise RayException(message)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_namespace_packages
 
-version = "0.1.5"
+version = "0.1.5rc0"
 
 def get_long_description() -> str:
     with open("README.md") as fh:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_namespace_packages
 
-version = "0.1.4"
+version = "0.1.5"
 
 def get_long_description() -> str:
     with open("README.md") as fh:


### PR DESCRIPTION
## Feature: Add options to spin up Ray dashboard on Control Node 

Currently starting Ray dashboard is best effort, in this PR we are adding functionality that will allow users to explicitly spin up Ray dashboard on the control node of the Ray cluster. This will be useful for users and setups where its possible to route network traffic to/from the task pod, since in those cases we will be able to expose the Ray UI to the users. 

## Fix: ray nodes never join the cluster

**Problem.** #22 started passing a per-task `--temp-dir` to `ray start`. Ray records the cluster's address in `<temp_dir>/ray_current_cluster`, but an address-less `ray.init()` only looks in the *default* temp dir. With the address file relocated, `ray.init()` finds nothing and takes its documented fallback path: it starts a brand new single-node cluster.

Two consequences on `main` (unreleased — 0.1.4 is unaffected):

- `ray_started_check.py` always reported a 1-node cluster, so `wait_for_ray_nodes_to_join` never matched `num_nodes` and every multi-node step died with `All 'ray' nodes did not join the cluster in N seconds`.
- Worse, user step code calling bare `ray.init()` silently ran on its own 1-node cluster while the real cluster sat idle. Any multi-node results from `main` are suspect.

**Fix.**

- Stop passing `--temp-dir` and let ray use its default temp dir, so ray's own discovery works as documented. `default_ray_temp_dir()` resolves it across versions (the helper moved from `ray._private.utils.get_ray_temp_dir` to `ray._common.utils.get_default_ray_temp_dir` in ray 2.40). Worker log tailing is unaffected — it resolves `<temp_dir>/session_latest/logs` either way.
- The node probe now connects explicitly via `ray.init(address="<main_ip>:<main_port>")`, so it can never fall through to starting its own cluster.
- `_extract_ray_nodes` returns `(nodes, error)` instead of swallowing the subprocess's stderr, and the waiting/timeout messages now include the real reason. This failure was previously undiagnosable from task logs.
- Fixed a `len(None)` crash in `wait_for_ray_nodes_to_join`: whenever the probe failed, `len(ray_nodes)` raised `TypeError: object of type 'NoneType' has no len()` on the very first iteration (`_iters % 10 == 0` is true at 0), masking the underlying error.

**Testing.** Stubbed unit checks cover the wait loop (stuck-at-1, probe failure, malformed output, happy path) and the emitted `ray start` argv. Tested on a real multi-node run to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
